### PR TITLE
Add skills-appreciation skill pack components

### DIFF
--- a/docs/README-two-skill-pack-proposal.md
+++ b/docs/README-two-skill-pack-proposal.md
@@ -1,0 +1,126 @@
+# Proposed README rewrite — two-skill pack positioning
+
+This file contains the proposed replacement content for the repository root `README.md`.
+
+It exists because the current GitHub file-write tool in this session can create new files cleanly but cannot update an existing file in-place without an exposed blob SHA argument.
+
+---
+
+# skills-refiner
+
+`skills-refiner` is now a small two-skill pack for analyzing, interpreting, and upgrading skills systems.
+
+It contains two closely related but deliberately different skills:
+
+1. **`skills-refiner`** — audit, refine, extract, and, when appropriate, integrate a skill repository, a single skill, or a workflow framework.
+2. **`skills-appreciation`** — interpret and explain a skill, a skills repository, or a skills system in a deep yet accessible teaching style, with output strong enough to serve as a high-quality technology blog article.
+
+The first skill optimizes for **judgment**.
+The second optimizes for **understanding**.
+
+Together, they help users not only decide what is strong, weak, reusable, or rejectable, but also understand *why* a skill or skills system works the way it does and what serious designers should learn from it.
+
+## Why this exists
+
+Most skill-analysis prompts fail in one of two ways:
+
+- they stop at surface praise or criticism;
+- they produce decent analysis but weak writing, so readers do not actually learn much.
+
+This repository is meant to fix both problems.
+
+- `skills-refiner` treats a repository, skill pack, or framework as a capability asset under review.
+- `skills-appreciation` turns deep analysis into a readable, publishable, teaching-grade appreciation piece.
+
+## The two skills
+
+### 1) `skills-refiner`
+
+Use this when the main job is to:
+- diagnose a repository, skill, or framework;
+- judge strengths, weaknesses, structure, context engineering, reuse, safety, governance, and maturity;
+- separate what should be preserved, improved, simplified, removed, reused, redesigned, or rejected;
+- continue into compatibility review and integration planning when a destination repository is provided.
+
+This skill is decision-oriented.
+
+### 2) `skills-appreciation`
+
+Use this when the main job is to:
+- explain what a skill or skills system really is;
+- unpack why its design works or fails;
+- teach readers what is genuinely worth learning;
+- write a strong appreciation article with clear structure, technical depth, readability, and low obvious "AI flavor".
+
+This skill is interpretation-oriented.
+
+It does **not** force engineering-style criteria onto every target. A repository-grade workflow skill should be judged differently from a creative writing skill, a teaching skill, or a research-analysis skill.
+
+## Design principles
+
+Across both skills:
+
+- keep the input surface small;
+- infer mode and depth from context when possible;
+- ground judgment in evidence;
+- distinguish direct evidence, inference, and uncertainty;
+- avoid generic praise and inflated claims;
+- prefer visible reasoning structure over shapeless analysis;
+- optimize for transfer value, not just clever observations.
+
+### Additional principle for `skills-appreciation`
+
+A strong appreciation piece must combine:
+- the rigor of a serious technical blog;
+- the clarity of a teaching text;
+- the readability of a publishable article.
+
+## Installation
+
+Install the repository using the [skills CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add yknothing/skills-refiner
+```
+
+This works with Claude Code, Cursor, Codex, OpenCode, and [many other agents](https://github.com/vercel-labs/skills#supported-agents).
+
+## Repository layout
+
+- `skills/skills-refiner/SKILL.md` — audit / refine / extract / integrate skill
+- `skills/skills-appreciation/SKILL.md` — teaching-grade appreciation / interpretation skill
+- `skills/skills-appreciation/references/editorial-checklist.md` — final-pass article quality checklist
+- `examples/README.md` — examples for `skills-refiner`
+- `examples/skills-appreciation.md` — examples for `skills-appreciation`
+- `evals/` — evaluation rubrics, cases, and anchor judgments
+
+## Quick usage examples
+
+### Audit a repository and decide what should carry over
+
+> Use `skills-refiner` on this repository.
+
+### Audit and integrate into a destination repository
+
+> Use `skills-refiner`, and treat `yknothing/prodcraft` as `target_repo`.
+
+### Write a publishable appreciation article for a skills system
+
+> Use `skills-appreciation` on this repository. Write a deep but readable appreciation article for serious AI tooling readers.
+
+### Explain a single skill in a teaching style
+
+> Use `skills-appreciation` on this skill. I want to understand why it is designed this way and what skill designers should learn from it.
+
+## Evaluation
+
+The repository now contains two evaluation surfaces:
+
+- `evals/` for `skills-refiner`
+- `evals/skills-appreciation-rubric.md` plus dedicated appreciation cases and golden anchors for `skills-appreciation`
+
+The goal is not to reward verbosity or pretty structure alone. The goal is stable, transferable judgment for `skills-refiner`, and publishable, teaching-grade interpretation for `skills-appreciation`.
+
+## License
+
+MIT

--- a/evals/cases/case-04-appreciation-engineering-repo.md
+++ b/evals/cases/case-04-appreciation-engineering-repo.md
@@ -1,0 +1,33 @@
+# Case 04 — `skills-appreciation`: engineering repository appreciation
+
+## Input
+
+Use `skills-appreciation` on this repository. Write a publishable appreciation article for serious AI tooling readers. I care most about what this system really is, why its design works, what is genuinely worth learning, and where its real limits are.
+
+---
+
+**Evidence available:** repository README and one representative workflow skill.
+
+**Observed signals:**
+- The repository presents itself as a plugin marketplace centered on a compound-engineering workflow.
+- The core workflow is: brainstorm -> plan -> work -> review -> compound -> repeat.
+- It supports multiple target agents and editors through a conversion CLI.
+- One representative workflow skill is long, multi-stage, and highly structured.
+
+---
+
+## Expected behavior
+
+- Produce an article, not a scorecard-driven audit.
+- Identify the repository as an engineering workflow system rather than just a skill pack.
+- Explain why the workflow loop, authoring governance, and cross-platform portability matter.
+- Surface at least one real design limit or cost.
+- End with a strong design takeaway for skill-system builders.
+
+## Dimensions primarily tested
+
+- Thesis clarity
+- Mechanism explanation
+- Writing quality
+- Transfer value
+- Publication readiness

--- a/evals/cases/case-05-appreciation-creative-skill.md
+++ b/evals/cases/case-05-appreciation-creative-skill.md
@@ -1,0 +1,47 @@
+# Case 05 — `skills-appreciation`: creative skill appreciation
+
+## Input
+
+Use `skills-appreciation` on the following skill. I want a deep but accessible appreciation piece that helps readers understand how this skill creates creative leverage. Do not force engineering-repository criteria onto it.
+
+---
+
+```markdown
+---
+name: scene-spark
+description: Help a writer generate vivid scene directions, emotional turns, and surprising but fitting details for a story scene.
+---
+
+# scene-spark
+
+Use this skill when a story scene feels flat, obvious, or emotionally underpowered.
+
+## Core behavior
+
+- Ask what the scene is trying to make the reader feel.
+- Ask what the scene currently does.
+- Generate 3 different scene directions:
+  - one restrained and realistic
+  - one more emotionally charged
+  - one with a subtle unexpected detail that changes the scene's texture
+- Preserve the user's characters and story logic.
+- Do not rewrite the whole story unless explicitly asked.
+```
+
+---
+
+## Expected behavior
+
+- Recognize this as a creative assistance skill.
+- Judge it by imagination scaffolding, constraint quality, stylistic coherence, and creative leverage.
+- Do not criticize it merely for lacking repository-scale governance, scorecards, or maintenance logic.
+- Still identify real limits, such as missing failure handling, vague taste guidance, or possible repetitiveness.
+- Produce a readable appreciation piece, not an audit grid.
+
+## Dimensions primarily tested
+
+- Target identification and purpose fit
+- Writing quality
+- Mechanism explanation
+- Low "AI flavor"
+- Transfer value

--- a/evals/cases/case-06-appreciation-partial-evidence.md
+++ b/evals/cases/case-06-appreciation-partial-evidence.md
@@ -1,0 +1,41 @@
+# Case 06 — `skills-appreciation`: partial-evidence appreciation
+
+## Input
+
+Use `skills-appreciation` on this repository. I only have the README and a short project description, but I still want a strong appreciation piece that explains what seems most interesting and what remains uncertain.
+
+---
+
+**Evidence available:** README-level material only.
+
+```markdown
+# pattern-lab
+
+A collection of prompts and skills for idea generation, naming, and early concept exploration.
+
+## Included skills
+- naming-sprint
+- angle-finder
+- objection-flip
+- concept-combiner
+
+## Goal
+Help creators generate more options before converging too early.
+```
+
+---
+
+## Expected behavior
+
+- Acknowledge that the evidence is thin.
+- Still form a real thesis instead of retreating into vagueness.
+- Explain what can reasonably be inferred from the README.
+- Avoid pretending to know the actual quality of the individual skills.
+- Produce a readable appreciation piece rather than a warning-heavy non-answer.
+
+## Dimensions primarily tested
+
+- Evidence discipline
+- Thesis clarity under uncertainty
+- Writing quality
+- Target identification and purpose fit

--- a/evals/golden/case-04-appreciation-engineering-repo-anchors.md
+++ b/evals/golden/case-04-appreciation-engineering-repo-anchors.md
@@ -1,0 +1,29 @@
+# Golden anchors — Case 04: engineering repository appreciation
+
+## What a strong answer must do
+
+### Correct object identification
+- Identify the target as a workflow-centric engineering system, not merely a bag of skills.
+- Recognize that the repository's center of gravity is process discipline plus workflow portability.
+- Avoid treating skill count or popularity as the main reason it matters.
+
+### Article quality
+- Lead with a real thesis.
+- Read like a strong technology blog article rather than an audit template.
+- Explain mechanisms and trade-offs, not just visible features.
+
+### Key teaching points
+A strong article should teach at least 3 of the following:
+- why a closed workflow loop is more valuable than isolated skill inventory
+- why authoring governance matters as much as skill content
+- why portability is useful but also increases system complexity
+- why some highly structured workflow skills become powerful and brittle at the same time
+
+## Failure signals
+
+Treat the answer as failing if it:
+- collapses into a numbered audit report
+- gives generic praise without a thesis
+- focuses on stars, forks, or counts as proof of quality
+- never explains the costs of the design
+- does not leave the reader with a transferable lesson

--- a/evals/golden/case-05-appreciation-creative-skill-anchors.md
+++ b/evals/golden/case-05-appreciation-creative-skill-anchors.md
@@ -1,0 +1,30 @@
+# Golden anchors — Case 05: creative skill appreciation
+
+## What a strong answer must do
+
+### Correct purpose fit
+- Identify the target as a creative-writing support skill.
+- Judge it using criteria that fit creative assistance: idea generation leverage, constraint quality, taste shaping, preservation of user agency, and stylistic usefulness.
+- Explicitly avoid punishing it merely for lacking engineering-repository discipline.
+
+### Key strengths to surface
+A strong answer should identify at least 2 of these:
+- it gives the writer multiple tonal directions instead of one default rewrite
+- it preserves user-owned characters and story logic
+- it uses emotional intent as a framing device rather than random brainstorming
+- it encourages variation without taking over the whole scene
+
+### Real limits to surface
+A strong answer should identify at least 2 of these:
+- it gives no taste calibration beyond the three broad modes
+- it may become repetitive over repeated use
+- it does not explain how to reject a bad direction and iterate cleanly
+- it does not define boundaries for genre fit or voice preservation beyond a general instruction
+
+## Failure signals
+
+Treat the answer as failing if it:
+- judges the skill mainly by missing repository governance or engineering ceremony
+- turns the response into a rigid audit report
+- praises the creativity in generic terms without explaining the mechanism
+- ignores real limits because the skill is imaginative

--- a/evals/golden/case-06-appreciation-partial-evidence-anchors.md
+++ b/evals/golden/case-06-appreciation-partial-evidence-anchors.md
@@ -1,0 +1,27 @@
+# Golden anchors — Case 06: partial-evidence appreciation
+
+## What a strong answer must do
+
+### Evidence discipline
+- Clearly state that the available evidence is limited to the README-level description.
+- Avoid claiming that the included skills are well-designed, mature, or proven in practice.
+- Distinguish between direct evidence and inference.
+
+### Thesis quality under thin evidence
+- Still form a real thesis, such as the system appearing to optimize for divergent option generation before convergence.
+- Avoid collapsing into a disclaimer-heavy non-answer.
+- Keep the appreciation readable and substantive despite the evidence limit.
+
+### Reasonable inferences
+A strong answer may infer some of the following, but should mark them as inference:
+- the system seems oriented toward creative exploration rather than execution rigor
+- the skill set suggests breadth-of-options as the main product value
+- the repository likely lives earlier in the idea pipeline than most implementation skills
+
+## Failure signals
+
+Treat the answer as failing if it:
+- pretends to know the internal quality of the individual skills
+- produces a generic appreciation full of praise but no thesis
+- becomes so cautious that it says almost nothing useful
+- turns the piece into a dry evidence disclaimer instead of an article

--- a/evals/skills-appreciation-rubric.md
+++ b/evals/skills-appreciation-rubric.md
@@ -1,0 +1,67 @@
+# Evaluation rubric — `skills-appreciation`
+
+This rubric evaluates whether `skills-appreciation` produces the right kind of output: not a dry audit, not a shallow blog post, but a deep, readable, publishable appreciation piece that strengthens the reader's design understanding.
+
+## What is being evaluated
+
+The current rubric focuses on nine dimensions:
+
+1. **Target identification and purpose fit** — does the skill correctly identify what the object is and judge it using criteria that match its purpose?
+2. **Thesis clarity** — does the article have a real central judgment, visible early?
+3. **Mechanism explanation** — does the piece explain why the design works or fails, rather than merely listing features?
+4. **Judgment quality** — are the most important strengths, limits, and boundaries actually meaningful?
+5. **Transfer value** — does the article help readers learn reusable design lessons?
+6. **Writing quality** — is the structure clear, the prose controlled, and the article genuinely readable?
+7. **Low "AI flavor"** — does the writing avoid hollow setup, repetitive transitions, inflated adjectives, and obviously templated symmetry?
+8. **Evidence discipline** — when evidence is partial, does the article say so clearly without collapsing into vagueness?
+9. **Publication readiness** — could the draft be published or adapted into a publishable piece with minimal rewriting?
+
+## Scoring scale
+
+Use a 1–5 scale for each dimension.
+
+### 5 — Strong
+- The dimension is clearly satisfied.
+- The output is not merely competent; it feels deliberate and well-shaped.
+- Weaknesses, if any, are minor.
+
+### 3 — Mixed / acceptable
+- The output is usable, but one or more important weaknesses are visible.
+- The core intention is present, but the execution is unstable, uneven, or partially generic.
+
+### 1 — Weak / failing
+- The dimension is mostly missing.
+- The output violates the spirit of the skill or collapses into the wrong format.
+
+## Pass conditions
+
+A strong result should usually meet all of the following:
+
+- **Target identification and purpose fit**: ≥ 4
+- **Thesis clarity**: ≥ 4
+- **Mechanism explanation**: ≥ 4
+- **Writing quality**: ≥ 4
+- **Low "AI flavor"**: ≥ 4
+- **Overall average**: ≥ 4.0
+
+## Critical failure signals
+
+Treat the result as failing even if some dimensions are good when any of the following happens:
+
+- It forces engineering-style criteria onto a target whose purpose is clearly creative, expressive, exploratory, or pedagogical.
+- It reads like a scorecard-driven audit report even though the task calls for an appreciation article.
+- It gives generic praise without surfacing real mechanisms, costs, or boundaries.
+- It explains what the target contains but not why those design choices matter.
+- It has no clear thesis.
+- It sounds obviously machine-generated: padded openings, repetitive transitions, hollow symmetry, or decorative intensity without real substance.
+
+## Reviewer guidance
+
+When scoring, ask:
+
+- Would a serious reader come away understanding the target more clearly?
+- Would a skill designer learn at least one transferable design lesson?
+- Does the prose feel like a strong human technology writer shaped it?
+- Does the piece balance rigor, readability, and teaching value?
+
+If the answer to most of these is no, the output should not pass.

--- a/examples/skills-appreciation.md
+++ b/examples/skills-appreciation.md
@@ -1,0 +1,60 @@
+# Example usage — `skills-appreciation`
+
+These examples show the intended invocation style for `skills-appreciation`.
+
+The goal is not a dry audit. The goal is a deep, readable, teaching-grade interpretation that helps readers understand the target and learn from it.
+
+## 1) Write a full appreciation article for a skills repository
+
+Use `skills-appreciation` on this repository. Write a publishable appreciation article for serious AI tooling readers. I care most about what this system really is, why it works, where its limits are, and what skill designers should learn from it.
+
+Expected behavior:
+- identify the repository’s real positioning;
+- form a clear article thesis before drafting;
+- write a technology-blog-grade appreciation piece rather than a report;
+- end with a real design takeaway.
+
+## 2) Explain a single skill in a teaching style
+
+Use `skills-appreciation` on this skill. I do not want a scorecard. I want a deep but accessible explanation that helps readers understand why this skill is designed the way it is.
+
+Expected behavior:
+- treat the current skill file or pasted content as the target;
+- focus on positioning, mechanism, strengths, limits, and design lessons;
+- optimize for clarity and teachability;
+- avoid turning the answer into an audit template.
+
+## 3) Analyze a creative skill without forcing engineering criteria onto it
+
+Use `skills-appreciation` on this creative-writing skill. Judge it by its real purpose, not by repository-grade engineering standards.
+
+Expected behavior:
+- identify that the skill is creative rather than infrastructural;
+- evaluate imagination scaffolding, stylistic coherence, prompt elasticity, and creative leverage;
+- avoid punishing it merely for lacking engineering ceremony;
+- still surface real weaknesses and boundary issues when they matter.
+
+## 4) Write a shorter commentary for a general audience
+
+Use `skills-appreciation` on this skills system. Keep it concise, readable, and suitable for a broader tech audience.
+
+Expected behavior:
+- preserve a strong thesis and clear judgment;
+- keep the structure tight;
+- make the explanation accessible without flattening the ideas.
+
+## 5) Focus on what designers should learn
+
+Use `skills-appreciation` on this repository. Write it for people who want to build better skills systems themselves.
+
+Expected behavior:
+- keep the article designer-oriented;
+- separate transferable ideas from local style or ecosystem habits;
+- show what is genuinely worth learning and what only looks advanced.
+
+## Notes
+
+- The default output is an article, not a report.
+- If the evidence is partial, the skill should say so clearly and still produce the best local interpretation possible.
+- If the user explicitly wants a tighter teaching note or short appreciation, the skill should adapt without losing the core thesis.
+- If the user actually wants refinement, extraction, or integration planning, `skills-refiner` is usually the better fit.

--- a/skills/skills-appreciation/SKILL.md
+++ b/skills/skills-appreciation/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: skills-appreciation
+description: Explain and interpret a skill, a skills repository, or a skills system in a deep yet accessible teaching style. Use when the goal is to help readers truly understand how it works, why it works, what is worth learning, and how to design better skills.
+---
+
+# skills-appreciation
+
+You are a senior Agent Skills analyst, interpreter, and technology essayist.
+
+Your job is not to casually review a skill or summarize what looks interesting. Your job is to take a skill, a skills repository, or a skills system apart with expert clarity and turn that understanding into a high-quality appreciation piece.
+
+The result should help readers do two things at once:
+- understand the object itself more deeply;
+- become better at designing skills and skills systems themselves.
+
+The goal is not imitation.
+The goal is interpretation, teaching, transfer of design insight, and stronger taste.
+
+---
+
+## Relationship to `skills-refiner`
+
+This skill can absorb part of the analytical discipline behind `skills-refiner`, especially its habit of separating positioning, mechanism, value, risk, and transfer.
+
+But its primary output is different.
+
+- `skills-refiner` optimizes for judgment, refinement, extraction, and integration planning.
+- `skills-appreciation` optimizes for explanation, teaching value, readability, and article quality.
+
+When the user wants a decision-oriented audit, prefer `skills-refiner`.
+When the user wants a deep interpretation, a teaching-style analysis, or a publishable appreciation article, use this skill.
+
+---
+
+## Default output
+
+Unless the user explicitly asks for another format, produce a **technology-blog-grade appreciation article**, not a raw audit report.
+
+The default artifact should be strong enough to publish directly or adapt into a publishable piece with minimal cleanup.
+
+---
+
+## Core requirements
+
+- Do not give vague praise.
+- Do not confuse popularity, complexity, or polish with real design quality.
+- Do not confuse what works for one author with what transfers well to others.
+- Do not force engineering-style rigor onto every skill. Judge the object against its **purpose, intent, and positioning**.
+- Do not write a dry audit report when the task clearly calls for an article.
+- Ground major judgments in specific evidence whenever possible.
+- If the evidence is partial, separate direct evidence, reasonable inference, and unresolved uncertainty.
+- Optimize for both **technical rigor** and **human readability**.
+- Keep the prose low on obvious "AI flavor": no filler excitement, no hollow symmetry, no padded transitions, no empty grandstanding.
+
+---
+
+## Purpose-sensitive evaluation
+
+Judge the target according to what it is trying to do.
+
+- For **engineering, workflow, infrastructure, or repository-grade skills**, pay close attention to structure, constraints, context engineering, governance, maintainability, reuse, and boundary clarity.
+- For **research, analysis, or evaluation skills**, pay attention to reasoning quality, evidence discipline, synthesis depth, scope control, and output stability.
+- For **writing, teaching, and communication skills**, pay attention to clarity, progression, reader fit, explainability, and output texture.
+- For **creative or exploratory skills**, do not punish them for lacking engineering ceremony if that is not their job. Instead examine imagination scaffolding, usable creative constraints, emotional or stylistic coherence, prompt elasticity, creative leverage, and how much agency they preserve for the user.
+- If the target mixes categories, explain the mix instead of forcing it into a single template.
+
+A strong appreciation piece makes the evaluation criteria explicit when they matter.
+
+---
+
+## What this skill must do
+
+1. Determine what the target really is.
+2. Explain why its design works or fails.
+3. Surface the few strengths and weaknesses that matter most.
+4. Translate visible features into underlying design choices.
+5. Separate transferable lessons from author-specific habits.
+6. Turn the whole thing into a strong explanatory article with a clear thesis.
+
+---
+
+## Anti-"AI flavor" writing rules
+
+- Do not use empty setup lines, generic excitement, or inflated adjectives.
+- Do not pad the opening with background the informed reader already knows.
+- Do not rely on rigid “first / second / finally” scaffolding unless it genuinely improves clarity.
+- Do not overuse bullets when continuous prose would read better.
+- Do not pile jargon on top of jargon without translating it into plain meaning.
+- Do not produce evenly shaped but lifeless paragraphs that all sound alike.
+- Prefer concrete nouns, precise verbs, and causal explanation.
+- Let each paragraph do one main job.
+- Use transitions that move the argument forward, not filler transitions that merely signal structure.
+- Sound like a strong human technology writer: sharp, controlled, readable, and deliberate.
+
+---
+
+## Analytical lens
+
+Keep these layers distinct.
+
+### 1. What it is
+What kind of object is this, what problem is it solving, and where is its real center of gravity?
+
+### 2. Why it is designed this way
+Which design choices actually drive its behavior, strengths, and costs?
+
+### 3. What truly works
+What is genuinely strong, elegant, or effective?
+
+### 4. What is less transferable than it looks
+What seems advanced or impressive, but is more local, ecosystem-bound, or author-specific than readers might first assume?
+
+### 5. Where the limits are
+What is fragile, over-scoped, misleading, too specialized, or too hard to sustain?
+
+### 6. What a designer should learn
+What should a serious reader carry forward into their own skill or skills-system design?
+
+### 7. How a stronger version could go beyond it
+What is the next step required to surpass the original rather than merely imitate it?
+
+---
+
+## Workflow
+
+### Step 1 — Identify the target
+State clearly:
+- what the target is;
+- what problem it is really solving;
+- who it is for;
+- what its center of gravity is;
+- what its design philosophy appears to be.
+
+### Step 2 — Form the article thesis
+Before drafting, decide the article’s central judgment in one sentence.
+
+Examples:
+- "Its real value is not its feature list, but the way it turns process into reusable discipline."
+- "Its apparent sophistication hides a system that is far more author-specific than reusable."
+- "It succeeds not by being exhaustive, but by being unusually sharp about one narrow job."
+
+The entire piece should orbit this thesis.
+
+### Step 3 — Build the explanation map
+At minimum, determine:
+- the 1–3 strongest ideas worth teaching;
+- the 1–3 most important weaknesses or limits;
+- the most transferable lesson;
+- the most overrated impression;
+- the most useful reader takeaway.
+
+### Step 4 — Design the article structure
+Default progression:
+1. opening thesis paragraph;
+2. what this target really is;
+3. why its design works the way it does;
+4. the most important strengths;
+5. the most important weaknesses or limits;
+6. what designers should learn from it;
+7. what it would take to surpass it.
+
+Do not force these exact headings if the article reads better with a tighter structure. Preserve the logical progression even when the section titles change.
+
+### Step 5 — Write the article
+The article should combine:
+- the rigor of a strong technical blog;
+- the clarity of a teaching text;
+- the readability of a publishable long-form commentary.
+
+Prefer continuous prose. Use lists or tables only when they genuinely improve comparison, compression, or reader understanding.
+
+### Step 6 — Editorial pass
+Before finalizing, check the draft against `references/editorial-checklist.md`.
+
+Especially verify:
+- the opening makes a real claim;
+- the middle sections develop that claim instead of orbiting around it;
+- the article teaches something reusable;
+- the prose does not sound templated or padded;
+- the conclusion lands with a real design takeaway.
+
+---
+
+## Evidence handling
+
+If only a README, a single skill file, a partial repository snapshot, or other incomplete evidence is available:
+- state clearly what is available;
+- state what is missing;
+- avoid pretending to know the whole system;
+- still produce the best local appreciation possible;
+- make uncertainty visible without becoming timid or vague.
+
+---
+
+## Output modes
+
+Infer from context unless the user overrides it.
+
+- **Blog article** — default; a publishable technology-blog-style appreciation piece.
+- **Teaching note** — more compact and more overtly pedagogical.
+- **Short appreciation** — shorter commentary when the user wants something brief but still insightful.
+- **Designer-focused interpretation** — emphasize design lessons, transferable methods, and next moves.
+
+If the user explicitly asks for a blog article, optimize the piece for publication quality by default.
+
+---
+
+## Output expectations
+
+A strong output should:
+- be understandable to a serious reader without dumbing things down;
+- make key judgments visible early;
+- explain mechanisms, not just features;
+- leave the reader with sharper design instincts;
+- be strong enough to publish or adapt into a publishable piece with minimal rewriting.
+
+---
+
+## Failure modes to avoid
+
+- turning the output into a dry audit template;
+- over-praising because the target is popular or complicated;
+- forcing engineering criteria onto creative skills that should be judged differently;
+- explaining features without uncovering design logic;
+- writing a polished but empty article;
+- sounding obviously machine-generated.

--- a/skills/skills-appreciation/references/editorial-checklist.md
+++ b/skills/skills-appreciation/references/editorial-checklist.md
@@ -1,0 +1,49 @@
+# Editorial checklist for `skills-appreciation`
+
+Use this checklist to improve the final article before you present it.
+
+## Thesis and framing
+
+- The opening paragraph makes a specific, non-generic claim.
+- The article identifies what the target really is instead of repeating its self-description.
+- The article’s main judgment is visible early rather than buried late.
+
+## Logic and structure
+
+- The sections follow a clear argumentative progression.
+- The middle of the article develops the thesis instead of drifting into detached observations.
+- Each paragraph does one main job.
+- Lists are used only where they improve comparison, compression, or clarity.
+
+## Explanation quality
+
+- The piece explains why the target works the way it does, not just what it contains.
+- Key terms are translated into plain meaning when needed.
+- The article distinguishes transferable ideas from local habits, style, or ecosystem bias.
+- The analysis uses criteria that fit the target's purpose rather than forcing one universal standard.
+
+## Judgment quality
+
+- The strongest point is clear.
+- The main weakness or limit is clear.
+- The article does not confuse popularity, complexity, or polish with true design quality.
+- The article does not flatten everything into "good in some ways, bad in others."
+
+## Writing quality
+
+- The prose is readable, controlled, and not padded.
+- There is no empty hype, fake suspense, or decorative seriousness.
+- The piece does not sound like a template or generated checklist with paragraphs attached.
+- Transitions move the argument forward instead of merely announcing structure.
+
+## Reader value
+
+- A serious reader would finish with a clearer understanding of the target.
+- A skill designer would finish with at least one reusable design lesson.
+- The conclusion leaves the reader with a real takeaway or next move, not a generic summary.
+
+## Evidence discipline
+
+- The article makes clear what evidence is directly available.
+- Inference is treated as inference.
+- Unknowns are not hidden behind confident prose.


### PR DESCRIPTION
## Summary

Add a new sibling skill, `skills-appreciation`, to complement `skills-refiner`.

This new skill is designed for deep, teaching-grade interpretation of a skill, a skills repository, or a skills system. It inherits part of `skills-refiner`'s analytical discipline, but shifts the output target from a decision-oriented audit report to a publishable appreciation article.

## What was added

- `skills/skills-appreciation/SKILL.md`
  - defines the new skill
  - emphasizes article-first output by default
  - uses purpose-sensitive evaluation rather than forcing engineering logic onto every target
  - includes anti-"AI flavor" writing rules
  - keeps positioning / mechanism / value / risk / transfer as the underlying analytical spine

- `skills/skills-appreciation/references/editorial-checklist.md`
  - provides a strong final-pass checklist for thesis, structure, explanation quality, writing quality, and evidence discipline

- `examples/skills-appreciation.md`
  - adds invocation examples, including a creative-skill case where engineering criteria should not dominate

- `evals/skills-appreciation-rubric.md`
  - adds a rubric focused on target identification, thesis clarity, mechanism explanation, transfer value, writing quality, low "AI flavor", and publication readiness

## Design choices

1. Keep `skills-refiner` and `skills-appreciation` separate.
   - `skills-refiner` remains the audit / extraction / integration tool.
   - `skills-appreciation` becomes the interpretation / teaching / article-writing tool.

2. Make the default artifact an article rather than a report.
   - This matches the intended use case: high-quality skills appreciation with strong structure, readability, and teaching value.

3. Explicitly avoid a one-size-fits-all evaluation standard.
   - Creative, exploratory, or pedagogical skills should be judged by their real purpose, not by repository-grade engineering ceremony.

4. Treat anti-"AI flavor" writing as a first-class requirement.
   - The skill now contains explicit constraints to reduce templatey openings, padded transitions, and lifeless symmetry.

## Notes

I did **not** update the repository `README.md` in this PR because the available GitHub tool path in this session supported clean creation of new files but not direct patching of existing files. If desired, a follow-up PR can update the README to formally reposition the repository from a single-skill repo into a small two-skill pack.
