### PR TITLE
Fix cross-platform governance CI contracts

### DIFF
--- a/skills/skill-debug/bin/skill-trace.sh
+++ b/skills/skill-debug/bin/skill-trace.sh
@@ -153,7 +153,7 @@ inject_trace() {
 
     # Find the end of frontmatter and inject after it
     local fm_end
-    if ! fm_end=$(awk '{
+    if ! fm_end=$(LC_ALL=C awk '{
         line=$0
         sub(/\r$/, "", line)
         if (NR == 1) if (substr(line, 1, 3) == "\357\273\277") line=substr(line, 4)

--- a/skills/skill-debug/lib/common.sh
+++ b/skills/skill-debug/lib/common.sh
@@ -391,7 +391,9 @@ sr_strip_trace_blocks() {
     local source_final_newline=0 source_eof_state
     source_eof_state=$(sr_file_eof_state "$file") || return 1
     [ "$source_eof_state" = "newline" ] && source_final_newline=1
-    awk -v source_final_newline="$source_final_newline" '
+    # GNU awk on Git Bash otherwise applies text-mode CRLF translation. Other
+    # awk implementations treat BINMODE as an ordinary, harmless variable.
+    LC_ALL=C awk -v BINMODE=3 -v source_final_newline="$source_final_newline" '
         function clean(line) {
             sub(/\r$/, "", line)
             return line

--- a/skills/skill-debug/lib/common.sh
+++ b/skills/skill-debug/lib/common.sh
@@ -235,7 +235,7 @@ sr_json_escape() {
 sr_normalize_skill_content() {
     local file="$1"
     if ! sr_validate_trace_structure "$file"; then
-        awk '
+        LC_ALL=C awk '
             {
                 line=$0
                 sub(/\r$/, "", line)
@@ -245,7 +245,7 @@ sr_normalize_skill_content() {
         ' "$file" 2>/dev/null
         return
     fi
-    awk '
+    LC_ALL=C awk '
         function clean(line) {
             sub(/\r$/, "", line)
             return line
@@ -301,7 +301,7 @@ sr_hash_skill_file() {
 
 sr_skill_has_trace() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -320,7 +320,7 @@ sr_skill_has_trace() {
 
 sr_validate_trace_structure() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)

--- a/skills/skill-debug/lib/common.sh
+++ b/skills/skill-debug/lib/common.sh
@@ -451,7 +451,7 @@ sr_strip_trace_blocks() {
 
 sr_get_frontmatter_field() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         function top_key(line, raw, first, last) {
             if (line ~ /^[[:space:]]/ || line !~ /:/) return ""
             raw=line
@@ -484,7 +484,7 @@ sr_get_frontmatter_field() {
 
 sr_get_frontmatter_text() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         function top_key(line, raw, first, last) {
             if (line ~ /^[[:space:]]/ || line !~ /:/) return ""
             raw=line
@@ -526,7 +526,7 @@ sr_get_frontmatter_text() {
 
 sr_get_metadata_value() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -547,7 +547,7 @@ sr_get_metadata_value() {
 
 sr_frontmatter_keys_json() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -565,7 +565,7 @@ sr_frontmatter_keys_json() {
 
 sr_frontmatter_list_json() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -604,7 +604,7 @@ sr_frontmatter_list_json() {
 
 sr_hook_events_json() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)

--- a/skills/skill-hygiene/lib/common.sh
+++ b/skills/skill-hygiene/lib/common.sh
@@ -391,7 +391,9 @@ sr_strip_trace_blocks() {
     local source_final_newline=0 source_eof_state
     source_eof_state=$(sr_file_eof_state "$file") || return 1
     [ "$source_eof_state" = "newline" ] && source_final_newline=1
-    awk -v source_final_newline="$source_final_newline" '
+    # GNU awk on Git Bash otherwise applies text-mode CRLF translation. Other
+    # awk implementations treat BINMODE as an ordinary, harmless variable.
+    LC_ALL=C awk -v BINMODE=3 -v source_final_newline="$source_final_newline" '
         function clean(line) {
             sub(/\r$/, "", line)
             return line

--- a/skills/skill-hygiene/lib/common.sh
+++ b/skills/skill-hygiene/lib/common.sh
@@ -235,7 +235,7 @@ sr_json_escape() {
 sr_normalize_skill_content() {
     local file="$1"
     if ! sr_validate_trace_structure "$file"; then
-        awk '
+        LC_ALL=C awk '
             {
                 line=$0
                 sub(/\r$/, "", line)
@@ -245,7 +245,7 @@ sr_normalize_skill_content() {
         ' "$file" 2>/dev/null
         return
     fi
-    awk '
+    LC_ALL=C awk '
         function clean(line) {
             sub(/\r$/, "", line)
             return line
@@ -301,7 +301,7 @@ sr_hash_skill_file() {
 
 sr_skill_has_trace() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -320,7 +320,7 @@ sr_skill_has_trace() {
 
 sr_validate_trace_structure() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)

--- a/skills/skill-hygiene/lib/common.sh
+++ b/skills/skill-hygiene/lib/common.sh
@@ -451,7 +451,7 @@ sr_strip_trace_blocks() {
 
 sr_get_frontmatter_field() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         function top_key(line, raw, first, last) {
             if (line ~ /^[[:space:]]/ || line !~ /:/) return ""
             raw=line
@@ -484,7 +484,7 @@ sr_get_frontmatter_field() {
 
 sr_get_frontmatter_text() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         function top_key(line, raw, first, last) {
             if (line ~ /^[[:space:]]/ || line !~ /:/) return ""
             raw=line
@@ -526,7 +526,7 @@ sr_get_frontmatter_text() {
 
 sr_get_metadata_value() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -547,7 +547,7 @@ sr_get_metadata_value() {
 
 sr_frontmatter_keys_json() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -565,7 +565,7 @@ sr_frontmatter_keys_json() {
 
 sr_frontmatter_list_json() {
     local file="$1" key="$2"
-    awk -v key="$key" '
+    LC_ALL=C awk -v key="$key" '
         {
             line=$0
             sub(/\r$/, "", line)
@@ -604,7 +604,7 @@ sr_frontmatter_list_json() {
 
 sr_hook_events_json() {
     local file="$1"
-    awk '
+    LC_ALL=C awk '
         {
             line=$0
             sub(/\r$/, "", line)

--- a/skills/skill-hygiene/tests/test-scan.sh
+++ b/skills/skill-hygiene/tests/test-scan.sh
@@ -245,6 +245,7 @@ run_tests() {
     assert_eq "Pipe-to-shell flagged" "1" "$(echo "$json_output" | jq '[.skills[] | select(.flags[] == "pipe_to_shell")] | length')"
     assert_eq "Dangerous command flagged" "1" "$(echo "$json_output" | jq '[.skills[] | select(.flags[] == "dangerous_cmd")] | length')"
     assert_eq "Project repo skill excluded from global scan" "0" "$(echo "$json_output" | jq '[.skills[] | select(.name == "project-skill")] | length')"
+    assert_eq "BOM/CRLF frontmatter name is observed directly" "bom-crlf-skill" "$(echo "$json_output" | jq -r '.skills[] | select(.dir_name == "bom-crlf-skill") | .frontmatter.name')"
     assert_eq "BOM/CRLF static preflight remains unknown" "unknown" "$(echo "$json_output" | jq -r '.skills[] | select(.name == "bom-crlf-skill") | .runtime_contract.status')"
     assert_eq "BOM/CRLF static preflight does not claim loadable" "true" "$(echo "$json_output" | jq '.skills[] | select(.name == "bom-crlf-skill") | .runtime_contract.loadable == null')"
     assert_eq "BOM/CRLF frontmatter has no missing field blockers" "0" "$(echo "$json_output" | jq '[.skills[] | select(.name == "bom-crlf-skill") | .runtime_contract.load_blockers[]? | select(. == "missing_name" or . == "missing_description")] | length')"


### PR DESCRIPTION
## Summary
- make BOM/CRLF frontmatter parsing byte-locale stable on Ubuntu
- force binary awk I/O for byte-reversible trace stripping in Windows Git Bash
- add a direct BOM frontmatter-name regression assertion so directory-name fallback cannot hide parser failure

## Verification
- 4/4 skills discovered by `npx --yes skills@latest add . --list`
- frontmatter name/description/reference validation passed
- full local governance suite passed on macOS (348 assertions + doctor smoke)
- `bash -n`, ShellCheck 0.11.0 (`--severity=error`), and actionlint 1.7.12 passed

This PR repairs the two failures observed in governance-tests run 29096439969 after PR #9.