### PR TITLE
docs(adr): non-invasive observability and on-demand pack catalog

### DIFF
--- a/docs/adr/0001-non-invasive-skill-observability.md
+++ b/docs/adr/0001-non-invasive-skill-observability.md
@@ -1,0 +1,160 @@
+# ADR-0001: 非侵入式 Skill 用量观测
+
+- **Status:** Accepted with limitations  
+- **Date:** 2026-07-17  
+- **Deciders:** Product owner (host machine) + skills-refiner maintainers  
+- **Supersedes:** Implicit “canary inject = usage analytics” framing in `skill-debug` messaging  
+- **Related:** ADR-0002; machine `~/.agents/skills/DEBT-BACKLOG.md` D-10; `skill-debug` SKILL.md accuracy contract  
+
+## Context
+
+skills-refiner / `skill-debug` 曾通过向被监测 `SKILL.md` **注入 canary** 来近似统计激活。该路径存在：
+
+- 安全风险（额外 shell 指令面）
+- 合规风险（改写第三方/分发 skill）
+- 信度缺口（仅证明 “agent 执行了 canary”，不能证明发现/有用性）
+
+同时，主要 Agent 宿主已具备或正在具备 **运行时遥测**，但开放程度不一、常带隐私门禁，导致“原生似乎没开”的体感。
+
+## Decision
+
+采用 **宿主优先、分层降级** 的观测架构；**禁止**将 canary 注入作为默认产品化计量路径。
+
+```text
+L0  平台原生遥测（首选）
+L1  宿主 Hook（改配置，不改 SKILL.md）
+L2  会话旁路只读解析（transcript / 本地日志）
+L3  Canary 注入（显式同意、可 strip、禁止进入分发物）
+```
+
+### Binding rules
+
+1. **计量边界在宿主运行时**，不在 skill 文件内容侧。
+2. `skill-probe` 继续只回答发现面问题（非侵入）。
+3. Canary / `skill-trace --inject*` 必须标注为 debug-only，且需用户显式确认。
+4. 跨 Agent 统一看板通过 **adapter 聚合** 实现，不发明侵入式跨平台协议。
+5. 任何导出真实 skill 名 / 工具细节的开关，必须按平台隐私门禁单独同意。
+
+## Platform capability snapshot (as of 2026-07-17)
+
+| Platform | Signal | Openness / gate |
+|---|---|---|
+| Claude Code | OTel event `claude_code.skill_activated`；`invocation_trigger` ∈ {`user-slash`,`claude-proactive`,`nested-skill`} | Opt-in: `CLAUDE_CODE_ENABLE_TELEMETRY=1`；自定义名默认可能为 `custom_skill`，真名需 `OTEL_LOG_TOOL_DETAILS=1` |
+| Cursor | Analytics API `GET /analytics/team/skills` | Enterprise + admin-scoped key；**无** Skill-use Hook（社区官方确认） |
+| Codex | Opt-in OTel（run/tool 级） | Skill 生命周期 hook（`PreSkillUse`/`PostSkillUse`）仍为诉求，不可假设已稳定 |
+
+Sources: Claude Code Monitoring docs; Cursor Analytics API docs / forum; Codex OTel docs & GitHub issues.
+
+## Consequences
+
+### Positive
+
+- 观测与 skill 分发解耦，降低安全/合规暴露面。
+- 与厂商隐私默认（红acted skill 名）对齐，避免绕过门禁。
+- 为 ADR-0002 的 pack 挂载事件（治理信号）留下非侵入扩展点。
+
+### Negative / limitations
+
+- 个人开发者可能暂时 **没有** Cursor Skills Analytics。
+- Claude 在未开 `OTEL_LOG_TOOL_DETAILS` 时，用量报表粒度不足。
+- 跨平台指标语义不一致（activation ≠ adoption ≠ usefulness）。
+- 在原生管道接通前，产品无法诚实声称“已掌握真实使用率”。
+
+### Non-goals
+
+- 不实现中央 SaaS 遥测后端（本 ADR 只定契约与最小本地采集）。
+- 不修改第三方 skill 正文以“补齐”统计。
+- 不把 canary 观察率当作质量或 ROI 证明。
+
+## Appendix B — Claude Code OTel → 本地 JSONL 最小采集
+
+> 本附录是 ADR-0001 的可执行补充（用户选项 B）。仅描述 **本机 opt-in** 管道；不向 Anthropic 额外发送数据（数据发往你配置的 OTLP 端点）。
+
+### B.1 常量（禁止魔法值散落）
+
+| 常量名 | 值 | 含义 |
+|---|---|---|
+| `ENV_TELEMETRY_ENABLE` | `CLAUDE_CODE_ENABLE_TELEMETRY` | 总开关 |
+| `ENV_OTEL_LOGS_EXPORTER` | `OTEL_LOGS_EXPORTER` | logs 导出器 |
+| `ENV_OTEL_EXPORTER_OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP 端点 |
+| `ENV_OTEL_LOG_TOOL_DETAILS` | `OTEL_LOG_TOOL_DETAILS` | 暴露真实 skill/工具细节（隐私敏感） |
+| `EVENT_SKILL_ACTIVATED` | `claude_code.skill_activated` | Skill 激活事件名 |
+| `DEFAULT_LOCAL_OTLP_ENDPOINT` | `http://127.0.0.1:4318` | 本机 collector 默认 HTTP 端点 |
+| `DEFAULT_JSONL_RELATIVE` | `.agents/debug/claude-skill-activated.jsonl` | 建议落盘相对 `$HOME` |
+
+### B.2 隐私门禁决策树
+
+```text
+需要计量？
+  ├─ 否 → 保持 TELEMETRY 关闭；只用 skill-probe
+  └─ 是 → 开启 ENV_TELEMETRY_ENABLE=1
+           ├─ 只要“有激活、不知真名” → 不要开 TOOL_DETAILS
+           └─ 需要按 skill 名聚合 → 显式同意后开 ENV_OTEL_LOG_TOOL_DETAILS=1
+                                      并记录同意时间/范围到运维笔记
+```
+
+**禁止：** 在未获同意时于共享机器或 CI 默认打开 `OTEL_LOG_TOOL_DETAILS` / `OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_RAW_API_BODIES`。
+
+**单独同意门禁：** `OTEL_LOG_TOOL_DETAILS=1` 不得与“打开遥测”捆绑默认开启。开启前须记录：同意人、时间、范围（本机/项目/团队）、预计关闭条件。未开此门禁时，报表只允许聚合到 `custom_skill` / 匿名桶，不得宣称“按 skill 名的采用率”。
+
+### B.3 推荐拓扑
+
+```text
+Claude Code ──OTLP/HTTP──► 本机 Collector / 简易接收器
+                              │
+                              └─► $HOME/.agents/debug/claude-skill-activated.jsonl
+```
+
+### B.4 最小环境示例（zsh）
+
+将下列片段写入 **个人** shell 配置或一次性 session（勿提交含密钥的配置到公开仓库）：
+
+```bash
+# --- ADR-0001 Appendix B: local-only Claude skill activation ---
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4318}"
+# 仅在明确需要真实 skill 名时取消下一行注释：
+# export OTEL_LOG_TOOL_DETAILS=1
+```
+
+### B.5 JSONL 事件契约（adapter 目标形状）
+
+采集器应将 `EVENT_SKILL_ACTIVATED` 归一为每行一个 JSON 对象，字段建议：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `schema` | string | 固定 `skills-refiner.claude-skill-activated.v1` |
+| `observed_at` | string | ISO-8601 |
+| `skill_name` | string | 可能为 `custom_skill`（未开 TOOL_DETAILS） |
+| `invocation_trigger` | string | `user-slash` \| `claude-proactive` \| `nested-skill` \| `unknown` |
+| `skill_source` | string \| null | 平台属性透传 |
+| `session_id` | string \| null | 若平台提供 |
+| `privacy_tool_details` | boolean | 本次管道是否开启 TOOL_DETAILS |
+
+### B.6 验收探针（人工）
+
+1. 启动本机 OTLP 接收端（或临时 console exporter）。  
+2. 开启 B.4 环境变量后启动 Claude Code。  
+3. 显式执行一个 slash skill / 触发一次 skill 激活。  
+4. 确认出现 `EVENT_SKILL_ACTIVATED`（或归一 JSONL 一行）。  
+5. **关闭** 遥测环境变量，确认不再产生新事件。
+
+### B.7 明确不保证
+
+- 不保证 Cursor / Codex 同期具备同等字段。  
+- 不保证 `custom_skill` 占位可被本地反解为真名。  
+- 不保证激活事件等于“技能有效”或“应保留该 skill”。
+
+## Validation
+
+- 对抗性评审：`docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/`  
+- 验收记录：`docs/verification/2026-07-17-observability-pack-catalog-acceptance.md`  
+
+## References
+
+- Claude Code Docs — Monitoring / OpenTelemetry  
+- Cursor Docs — Analytics API (`/analytics/team/skills`)  
+- Cursor Forum — “Hook on Skill usage” (no skill hook)  
+- Codex OTel configuration docs; GitHub issue on PreSkillUse/PostSkillUse  
+- `~/.agents/skills/skill-debug/SKILL.md` — Native Platform Signals First  

--- a/docs/adr/0002-on-demand-pack-catalog.md
+++ b/docs/adr/0002-on-demand-pack-catalog.md
@@ -1,0 +1,112 @@
+# ADR-0002: On-demand Pack Catalog（目录级渐进披露）
+
+- **Status:** Accepted with limitations  
+- **Date:** 2026-07-17  
+- **Deciders:** Product owner (host machine) + skills-refiner maintainers  
+- **Depends on:** ADR-0001（观测不依赖改 skill；pack mount 可作为治理信号）  
+- **Related:** machine `SCALE-ANALYSIS-2026-07-17.md`; Agent Skills progressive disclosure  
+
+## Context
+
+单个 skill 内部已有业界共识的三层渐进披露：
+
+1. `name` + `description`（发现）  
+2. `SKILL.md` 正文（激活）  
+3. references / scripts（执行）  
+
+但当全局 deploy 面达到 **~100+ skills** 时，**仅做 skill 内 PD 不够**：所有 description 仍会进入路由上下文（本机曾达 ~7k+ tokens）。需要 **目录级（catalog / pack）披露** 作为补充。
+
+业界对齐形态包括：Cloudflare `index.json` discovery RFC、Microsoft `skill://index.json` + `load_skill`、以及运维侧的 profile/pack 挂载。
+
+## Decision
+
+引入 **Pack Catalog** 作为部署编排契约（不是改写 skill 正文）：
+
+```text
+会话 / 工作域
+  → 读短 Catalog（Core + 可选包列表）
+  → 命中域 → 挂载对应 pack（发现面 symlink / profile）
+  → 宿主对已挂载 skill 做标准 L1/L2/L3
+  → 未挂载 skill 不进入 description 预算
+```
+
+### Binding rules
+
+1. Catalog 是 **部署意图**；在挂载工具落地前，不得声称“已节省 context”。  
+2. **禁止** 把全量 skill description 再抄进一个“超级索引 skill”（税换抽屉）。  
+3. Pack 边界必须可叙述（单一职责域）；路由器/索引文本保持短。  
+4. 不修改第三方 skill 正文以实现 On-demand。  
+5. 退役包（如 Lark）只出现在 Archive 引用，不出现在可挂载 pack。  
+6. Core 名单是 Owner 可修订的假设，须用 ADR-0001 的非侵入信号迭代，而非臆测永久正确。
+
+### Artifact
+
+权威草稿：
+
+[`artifacts/skills-pack-catalog.yaml`](artifacts/skills-pack-catalog.yaml)
+
+校验门禁：
+
+```bash
+node docs/adr/artifacts/validate-skills-pack-catalog.mjs
+```
+
+## Pack model
+
+| 层 | 名称 | 行为 |
+|---|---|---|
+| Core | `profile: core` | 默认应出现在主 Agent 发现面 |
+| On-demand | `packs.*.mount: on_demand` | 按工作域挂载 |
+| Archive | `archive` | 仅 shelf / 策略引用，不挂载 |
+
+### Design constraints (Done 方向)
+
+- 主发现面 skill 数目标：**≤ 80**，或 description 预算目标：**≤ ~4k tokens**（与机器侧 SCALE 分析一致，属目标而非当前事实）。  
+- Catalog 自身（不含全量 description）应保持可读、可人工 diff。
+
+## Consequences
+
+### Positive
+
+- 与 Agent Skills PD 互补，直击“description 路由税”。  
+- 与隔离/退役策略同构（Lark shelf 即 Archive）。  
+- 为未来 mount CLI / profile 切换提供稳定输入。
+
+### Negative / limitations
+
+- **当前未实施挂载运行时**：今日 Claude/Factory 仍可能看到几乎全量 symlink；Catalog  alone 不改变行为。  
+- Core 名单在缺少真实用量数据时带有主观性（鸡生蛋：观测 ADR-0001）。  
+- 切错 pack 会导致“skill 找不到”，需 UX/文档说明。  
+- 部分 Agent（Cursor）本就不是全量镜像 `~/.agents/skills`，pack 模型收益因宿主而异。
+
+### Non-goals
+
+- 本 ADR 不交付语义检索引擎。  
+- 不强制合并 `prodcraft` / `loopos` / `grilling` 控制面（见机器 `CONTROL-PLANE.md`）。  
+- 不自动删除 On-demand 包磁盘副本。
+
+## Implementation stages
+
+| Stage | Deliverable | Context savings? |
+|---|---|---|
+| S0 (本交付) | Catalog YAML + 校验 + ADR | 否（契约） |
+| S1 | `skills-pack-mount`（或等价）按 profile 增删发现面 symlink | 是（对支持全量发现的宿主） |
+| S2 | 会话启动读短索引 / 可选 router meta-skill | 是（若索引足够短） |
+| S3 | 用 ADR-0001 信号反馈修订 Core | 质量提升 |
+| S4 | 拆分 `residual_library` 为有界域包 | 降低“垃圾桶 pack”风险 |
+
+> **S0 诚实声明：** 在 S1 完成前，不得在对外叙述中声称“已通过 On-demand 节省 context”。
+
+## Validation
+
+- 对抗性评审：`docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/`  
+- 验收记录：`docs/verification/2026-07-17-observability-pack-catalog-acceptance.md`  
+- 门禁：`node docs/adr/artifacts/validate-skills-pack-catalog.mjs`  
+
+## References
+
+- agentskills.io — progressive disclosure  
+- Microsoft Learn — Agent Skills / `load_skill`  
+- Cloudflare `agent-skills-discovery-rfc`  
+- `~/.agents/skills/SCALE-ANALYSIS-2026-07-17.md`  
+- ADR-0001  

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records (ADR)
+
+本目录记录 skills-refiner 在 **Agent Skills 部署拓扑、观测与渐进披露** 上的架构决策，作为 `ARCHITECTURE` / 机器侧策略文档的仓库内补充。
+
+## 索引
+
+| ID | 标题 | 状态 | 日期 |
+|---|---|---|---|
+| [0001](0001-non-invasive-skill-observability.md) | 非侵入式 Skill 用量观测 | Accepted with limitations | 2026-07-17 |
+| [0002](0002-on-demand-pack-catalog.md) | On-demand Pack Catalog（目录级渐进披露） | Accepted with limitations | 2026-07-17 |
+
+## 产物
+
+| 路径 | 说明 |
+|---|---|
+| [artifacts/skills-pack-catalog.yaml](artifacts/skills-pack-catalog.yaml) | Core / On-demand 包地图（ADR-0002） |
+| [artifacts/validate-skills-pack-catalog.mjs](artifacts/validate-skills-pack-catalog.mjs) | Catalog 结构与存在性校验门禁 |
+
+## 对抗性评审与验收
+
+- 评审包：`docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/`
+- 验收：`docs/verification/2026-07-17-observability-pack-catalog-acceptance.md`
+
+## 约定
+
+1. ADR 编号单调递增；状态使用：`Proposed` / `Accepted` / `Accepted with limitations` / `Superseded` / `Rejected`。
+2. 机器侧 deploy 根（`~/.agents/skills`）策略与仓库 ADR 冲突时，以 **显式 Owner Decision** 为准，并在下一份 ADR 中调和。
+3. 本目录不替代平台厂商文档；引用外部能力时必须标注版本/门禁假设。

--- a/docs/adr/artifacts/skills-pack-catalog.yaml
+++ b/docs/adr/artifacts/skills-pack-catalog.yaml
@@ -1,0 +1,221 @@
+# skills-pack-catalog.yaml — ADR-0002 artifact (draft intent)
+# This file declares deployment intent. It does NOT mount/unmount discovery
+# surfaces by itself. See docs/adr/0002-on-demand-pack-catalog.md.
+
+schema_version: "1.0.0"
+catalog_id: skills-pack-catalog
+updated: "2026-07-17"
+status: draft
+enforcement: none
+
+# Named constants for status / mount enums (no magic strings in consumers).
+constants:
+  status:
+    draft: draft
+    active: active
+    deprecated: deprecated
+  mount:
+    always: always
+    on_demand: on_demand
+    never: never
+  enforcement:
+    none: none
+    advisory: advisory
+    hard: hard
+
+deploy_root_hint: "~/.agents/skills"
+notes:
+  - "Core list is an owner hypothesis pending non-invasive usage signals (ADR-0001)."
+  - "Skills listed under packs remain on disk; on_demand means they should not stay on the default discovery mount once S1 tooling exists."
+  - "Retired Lark and non-bs twins are archive-only; do not re-list as mountable."
+
+targets:
+  discoverable_skill_count_max: 80
+  description_budget_tokens_max: 4000
+
+profile:
+  id: core
+  mount: always
+  purpose: "Weekly high-frequency SDLC + governance + canonical bs-* entry points."
+  skills:
+    # Lifecycle spine
+    - prodcraft
+    - intake
+    - brainstorming
+    - writing-plans
+    - executing-plans
+    - spec-writing
+    - task-breakdown
+    - task-execution
+    - feature-development
+    - tdd
+    - systematic-debugging
+    - diagnosing-bugs
+    - code-review
+    - requesting-code-review
+    - receiving-code-review
+    - verification-before-completion
+    # Governance / meta
+    - skill-hygiene
+    - skill-debug
+    - skills-refiner
+    - skills-appreciation
+    - bs-skill-health
+    - bs-skill-bootstrap
+    - adversarial-product-pk
+    # Canonical Better-Skills (non-meta)
+    - bs-dev-flow
+    - bs-requirements-engineering
+    - bs-prose-craft
+    - bs-article-illustrate
+    - bs-social-card
+    - bs-first-customer-finder
+    # Common engineering glue
+    - documentation
+    - git-guardrails-claude-code
+    - security-audit
+    - testing-strategy
+    - delivery-completion
+
+packs:
+  loopos:
+    mount: on_demand
+    purpose: "Verifiable long-running autonomous loops; not a silent default for ordinary coding."
+    skills:
+      - loopos
+      - loopos-goal
+      - loopos-run
+      - loopos-compile
+      - loopos-review
+      - loopos-improve
+      - loopos-benchmark
+      - loopos-doctor
+      - loopos-accept
+      - loopos-recover
+
+  impeccable_design:
+    mount: on_demand
+    purpose: "Frontend polish / generation suite; heavy description and payload cost."
+    skills:
+      - impeccable
+      - frontend-design
+      - teach-impeccable
+      - adapt
+      - animate
+      - audit
+      - bolder
+      - clarify
+      - colorize
+      - critique
+      - delight
+      - distill
+      - extract
+      - harden
+      - normalize
+      - onboard
+      - optimize
+      - polish
+      - quieter
+
+  geo_seo:
+    mount: on_demand
+    purpose: "SEO / GEO specialist work."
+    skills:
+      - seo-geo
+
+  grilling:
+    mount: on_demand
+    purpose: "Adversarial plan interview; prefer user-invoked."
+    skills:
+      - grilling
+      - grill-me
+      - grill-with-docs
+
+  visual_gen:
+    mount: on_demand
+    purpose: "Image / slide / high-end visual generation packs."
+    skills:
+      - pptx
+      - image-to-code
+      - imagegen-frontend-web
+      - imagegen-frontend-mobile
+      - high-end-visual-design
+      - design-taste-frontend
+      - stitch-design-taste
+      - gpt-taste
+      - brandkit
+      - minimalist-ui
+
+  teaching_writing:
+    mount: on_demand
+    purpose: "Skill-authoring teaching surfaces; keep one teaching entry in Core via skills-appreciation."
+    skills:
+      - writing-skills
+      - writing-great-skills
+      - example-skill
+
+  residual_library:
+    mount: on_demand
+    purpose: "TEMPORARY catch-all for skills not yet assigned a coherent domain pack. Architecture debt (ADR-0002 S4): split before treating as stable end-state."
+    debt: split_before_stable
+    skills:
+      - acceptance-criteria
+      - accessibility
+      - api-design
+      - ask-matt
+      - bug-history-retrieval
+      - business-ops-analysis
+      - ci-cd
+      - compliance
+      - data-modeling
+      - decision-mapping
+      - deployment-strategy
+      - domain-modeling
+      - e2e-scenario-design
+      - estimation
+      - feasibility-study
+      - full-output-enforcement
+      - growth-pdca-ops
+      - handoff
+      - implementation-alignment-review
+      - implementation-integrity-audit
+      - incident-response
+      - internationalization
+      - langcraft
+      - loop-me
+      - market-analysis
+      - module-design
+      - monitoring-observability
+      - observability
+      - obsidian-vault
+      - philosophical-discourse
+      - playwright-cli
+      - problem-framing
+      - redesign-existing-projects
+      - refactoring
+      - release-management
+      - retrospective
+      - risk-assessment
+      - runbooks
+      - script-craft
+      - security-design
+      - sprint-planning
+      - system-design
+      - talantsai-frontier-hard-task-design
+      - tech-debt-management
+      - tech-selection
+      - tech-writing
+      - translation
+      - user-research
+      - using-superpowers
+
+archive:
+  mount: never
+  purpose: "Retired from global deploy/discovery; restore only with explicit owner exception."
+  references:
+    - id: lark-pack
+      shelf: "~/.agents/skills-quarantine/authoring-retired/2026-07-17-lark-retire"
+      policy: "~/.agents/skills/POLICY-LARK-RETIRED.md"
+    - id: non-bs-twins
+      shelf: "~/.agents/skills-quarantine/authoring-retired/2026-07-17-bs-canonical"
+      policy: "~/.agents/skills/POLICY-BS-CANONICAL.md"

--- a/docs/adr/artifacts/validate-skills-pack-catalog.mjs
+++ b/docs/adr/artifacts/validate-skills-pack-catalog.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Validates ADR-0002 skills-pack-catalog.yaml structure and membership.
+ * Does not mount skills. Exit 0 on success; non-zero on failure.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const CATALOG_PATH = join(SCRIPT_DIR, 'skills-pack-catalog.yaml');
+const HOME_DIR = homedir();
+const DEPLOY_ROOT = process.env.SKILLS_DEPLOY_ROOT
+  ? resolve(process.env.SKILLS_DEPLOY_ROOT)
+  : join(HOME_DIR, '.agents', 'skills');
+
+const EXIT_OK = 0;
+const EXIT_FAIL = 1;
+
+/**
+ * Redacts absolute home prefixes so logs/CI pastebacks do not leak usernames.
+ * @param {string} absolutePath
+ * @returns {string}
+ */
+function displayPath(absolutePath) {
+  const resolved = resolve(absolutePath);
+  if (resolved === HOME_DIR) return '~';
+  if (resolved.startsWith(`${HOME_DIR}/`)) {
+    return `~/${resolved.slice(HOME_DIR.length + 1)}`;
+  }
+  return resolved;
+}
+
+const REQUIRED_TOP_LEVEL = [
+  'schema_version',
+  'catalog_id',
+  'updated',
+  'status',
+  'enforcement',
+  'constants',
+  'profile',
+  'packs',
+  'archive',
+];
+
+/**
+ * Minimal YAML subset parser for this catalog shape (maps/lists/scalars).
+ * Avoids adding a dependency solely for ADR validation.
+ * @param {string} text
+ * @returns {unknown}
+ */
+function parseSimpleYaml(text) {
+  const lines = text.split(/\r?\n/);
+  const root = {};
+  const stack = [{ indent: -1, value: root, kind: 'map' }];
+
+  /**
+   * @param {string} raw
+   * @returns {string|number|boolean}
+   */
+  function parseScalar(raw) {
+    const v = raw.trim();
+    if (
+      (v.startsWith('"') && v.endsWith('"'))
+      || (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      return v.slice(1, -1);
+    }
+    if (v === 'true') return true;
+    if (v === 'false') return false;
+    if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v);
+    return v;
+  }
+
+  for (const line of lines) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const indent = line.match(/^\s*/)[0].length;
+    const trimmed = line.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1];
+
+    if (trimmed.startsWith('- ')) {
+      const itemRaw = trimmed.slice(2);
+      if (parent.kind !== 'list') {
+        throw new Error(`list item under non-list at: ${trimmed}`);
+      }
+      if (itemRaw.includes(':') && !itemRaw.startsWith('"') && !itemRaw.startsWith("'")) {
+        const map = {};
+        const idx = itemRaw.indexOf(':');
+        const k = itemRaw.slice(0, idx).trim();
+        const rest = itemRaw.slice(idx + 1).trim();
+        parent.value.push(map);
+        // Keep map on stack so subsequent deeper-indented keys attach to this item.
+        stack.push({ indent, value: map, kind: 'map' });
+        if (rest !== '') {
+          map[k] = parseScalar(rest);
+        } else {
+          const nested = {};
+          map[k] = nested;
+          stack.push({ indent: indent + 2, value: nested, kind: 'map' });
+        }
+      } else {
+        parent.value.push(parseScalar(itemRaw));
+      }
+      continue;
+    }
+
+    const colon = trimmed.indexOf(':');
+    if (colon < 0) throw new Error(`invalid line: ${trimmed}`);
+    const key = trimmed.slice(0, colon).trim();
+    const rest = trimmed.slice(colon + 1).trim();
+
+    if (parent.kind !== 'map') {
+      throw new Error(`map key under non-map: ${key}`);
+    }
+
+    if (rest === '') {
+      // Lookahead: next non-empty non-comment line decides list vs map.
+      let next = null;
+      for (let i = lines.indexOf(line) + 1; i < lines.length; i += 1) {
+        const cand = lines[i];
+        if (!cand.trim() || cand.trim().startsWith('#')) continue;
+        next = cand;
+        break;
+      }
+      const nextIndent = next ? next.match(/^\s*/)[0].length : indent;
+      const nextTrim = next ? next.trim() : '';
+      if (next && nextIndent > indent && nextTrim.startsWith('- ')) {
+        const list = [];
+        parent.value[key] = list;
+        stack.push({ indent, value: list, kind: 'list' });
+      } else {
+        const map = {};
+        parent.value[key] = map;
+        stack.push({ indent, value: map, kind: 'map' });
+      }
+    } else {
+      parent.value[key] = parseScalar(rest);
+    }
+  }
+
+  return root;
+}
+
+/**
+ * @param {unknown} catalog
+ * @returns {string[]}
+ */
+function collectCatalogSkills(catalog) {
+  /** @type {string[]} */
+  const names = [];
+  const profile = catalog.profile;
+  if (profile && Array.isArray(profile.skills)) {
+    names.push(...profile.skills);
+  }
+  const packs = catalog.packs || {};
+  for (const pack of Object.values(packs)) {
+    if (pack && Array.isArray(pack.skills)) {
+      names.push(...pack.skills);
+    }
+  }
+  return names;
+}
+
+/**
+ * @param {string} root
+ * @returns {Set<string>}
+ */
+function listDeploySkills(root) {
+  const set = new Set();
+  if (!existsSync(root)) return set;
+  for (const name of readdirSync(root)) {
+    if (name.startsWith('.')) continue;
+    const p = join(root, name);
+    try {
+      if (!statSync(p).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (existsSync(join(p, 'SKILL.md'))) set.add(name);
+  }
+  return set;
+}
+
+function main() {
+  /** @type {string[]} */
+  const errors = [];
+  /** @type {string[]} */
+  const warnings = [];
+
+  if (!existsSync(CATALOG_PATH)) {
+    console.error(`FAIL missing catalog: ${CATALOG_PATH}`);
+    process.exit(EXIT_FAIL);
+  }
+
+  let catalog;
+  try {
+    catalog = parseSimpleYaml(readFileSync(CATALOG_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`FAIL yaml parse: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(EXIT_FAIL);
+  }
+
+  for (const key of REQUIRED_TOP_LEVEL) {
+    if (catalog[key] === undefined) errors.push(`missing top-level key: ${key}`);
+  }
+
+  if (catalog.catalog_id !== 'skills-pack-catalog') {
+    errors.push(`catalog_id must be skills-pack-catalog, got ${catalog.catalog_id}`);
+  }
+  if (catalog.enforcement !== 'none' && catalog.status === 'draft') {
+    warnings.push('draft catalog usually keeps enforcement: none');
+  }
+
+  const mountAlways = catalog.constants?.mount?.always;
+  const mountOnDemand = catalog.constants?.mount?.on_demand;
+  const mountNever = catalog.constants?.mount?.never;
+  if (!mountAlways || !mountOnDemand || !mountNever) {
+    errors.push('constants.mount must define always, on_demand, never');
+  }
+
+  if (catalog.profile?.mount !== mountAlways) {
+    errors.push(`profile.mount must equal constants.mount.always (${mountAlways})`);
+  }
+  if (!Array.isArray(catalog.profile?.skills) || catalog.profile.skills.length === 0) {
+    errors.push('profile.skills must be a non-empty list');
+  }
+
+  for (const [packId, pack] of Object.entries(catalog.packs || {})) {
+    if (pack.mount !== mountOnDemand) {
+      errors.push(`pack ${packId}.mount must be ${mountOnDemand}`);
+    }
+    if (!Array.isArray(pack.skills) || pack.skills.length === 0) {
+      errors.push(`pack ${packId}.skills must be non-empty`);
+    }
+  }
+
+  if (catalog.archive?.mount !== mountNever) {
+    errors.push(`archive.mount must be ${mountNever}`);
+  }
+
+  const listed = collectCatalogSkills(catalog);
+  const dup = listed.filter((n, i) => listed.indexOf(n) !== i);
+  if (dup.length) {
+    errors.push(`duplicate skill membership: ${[...new Set(dup)].join(', ')}`);
+  }
+
+  const deploy = listDeploySkills(DEPLOY_ROOT);
+  if (deploy.size === 0) {
+    warnings.push(`deploy root empty or missing: ${DEPLOY_ROOT}`);
+  } else {
+    for (const name of listed) {
+      if (!deploy.has(name)) {
+        errors.push(`catalog skill not on deploy root: ${name}`);
+      }
+    }
+    const listedSet = new Set(listed);
+    const uncovered = [...deploy].filter((n) => !listedSet.has(n)).sort();
+    if (uncovered.length) {
+      errors.push(
+        `deploy skills missing from catalog (${uncovered.length}): ${uncovered.join(', ')}`,
+      );
+    }
+  }
+
+  const coreCount = catalog.profile?.skills?.length ?? 0;
+  const maxDiscoverable = catalog.targets?.discoverable_skill_count_max;
+  if (typeof maxDiscoverable === 'number' && coreCount > maxDiscoverable) {
+    errors.push(
+      `core size ${coreCount} exceeds targets.discoverable_skill_count_max ${maxDiscoverable}`,
+    );
+  }
+
+  console.log(`catalog: ${displayPath(CATALOG_PATH)}`);
+  console.log(`deploy_root: ${displayPath(DEPLOY_ROOT)}`);
+  console.log(`core_count: ${coreCount}`);
+  console.log(`listed_count: ${listed.length}`);
+  console.log(`deploy_count: ${deploy.size}`);
+
+  for (const w of warnings) console.warn(`WARN ${w}`);
+  for (const e of errors) console.error(`ERROR ${e}`);
+
+  if (errors.length) {
+    console.error(`FAIL ${errors.length} error(s)`);
+    process.exit(EXIT_FAIL);
+  }
+  console.log('PASS skills-pack-catalog validation');
+  process.exit(EXIT_OK);
+}
+
+main();

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/00-evidence-map.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/00-evidence-map.md
@@ -1,0 +1,42 @@
+# Evidence Map — Observability + Pack Catalog ADRs
+
+**Artifact target:** `docs/adr/0001-*.md`, `docs/adr/0002-*.md`, `docs/adr/artifacts/*`  
+**Snapshot date:** 2026-07-17  
+**Deploy root observed:** `~/.agents/skills` (129 skills post-Lark retire)
+
+## Canonical sources (current)
+
+| Source | Status | Use |
+|---|---|---|
+| Claude Code Monitoring docs (OTel / `claude_code.skill_activated`) | Verified via public docs fetch 2026-07-17 | ADR-0001 platform fact |
+| Cursor Analytics API `/analytics/team/skills` | Verified via public docs | Enterprise-gated adoption metrics |
+| Cursor forum “Hook on Skill usage” | Verified | No skill-use hook today |
+| Codex OTel docs + PreSkillUse issue | Verified as public | Incomplete skill lifecycle hooks |
+| `skill-debug` SKILL.md accuracy contract | On disk | Canary = proxy only |
+| Agent Skills PD / Microsoft Skills / Cloudflare discovery RFC | Public | ADR-0002 industry alignment |
+| `SCALE-ANALYSIS-2026-07-17.md` | Machine deploy docs | Scale targets |
+| Catalog validator run | Ran 2026-07-17 | `PASS` core=34 listed=129 deploy=129 |
+
+## Verified facts
+
+1. Canary inject modifies `SKILL.md` and is reversible only via strip; it is not platform-proof activation.  
+2. Claude emits skill activation OTel events when telemetry enabled; names may redact to `custom_skill` without `OTEL_LOG_TOOL_DETAILS`.  
+3. Cursor skills analytics exist for Enterprise; no documented personal local exporter equivalent.  
+4. Catalog YAML covers all 129 deploy skills with no duplicates (validator PASS).  
+5. Catalog `enforcement: none` — no mount runtime shipped in this change.
+
+## Assumptions
+
+- Owner wants architecture docs + draft catalog before mount tooling (S1).  
+- L1 adversarial review is acceptable for promoting ADRs to `docs/adr/` with limitations.
+
+## Missing / out of authority
+
+- Live Claude OTel session capture on this host (Appendix B not executed end-to-end here).  
+- Market proof that pack UX won’t increase “skill not found” support load.  
+- Cursor non-Enterprise usage metrics.
+
+## Stale risks
+
+- Do not cite pre-Lark “156 skills” as current without noting retire.  
+- Do not claim canary dashboard = usage analytics product.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/01-role-and-independence-declaration.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/01-role-and-independence-declaration.md
@@ -1,0 +1,20 @@
+# Role & Independence Declaration
+
+**Task:** Accept ADR-0001 (non-invasive observability + Appendix B) and ADR-0002 (pack catalog + artifact A) as architecture supplements.
+
+| Field | Value |
+|---|---|
+| Independence level | **L1 — role-separated, same session** |
+| Allowed wording | Role-separated review (**not** independent / external / L3) |
+| Champion runner | Same agent session |
+| Challenger runner | Same agent session (first pass drafted before synthesis; contamination risk acknowledged) |
+| Judge / Evidence Clerk | Same agent session |
+| Contamination | Shared prior conversation on observability & pack design; **not blind** across calendar time. Downgrade from any implied L2/L3. |
+| Model | Cursor Grok 4.5 (session) |
+
+## Visibility boundaries
+
+- Champion may argue for ADR acceptance and staged delivery.  
+- Challenger must attack false readiness, privacy, and catalog theater.  
+- Judge may not call this L3/L4.  
+- Acceptance may certify **artifact package readiness**, not production mount savings or org-wide telemetry rollout.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/02-champion-first-pass.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/02-champion-first-pass.md
@@ -1,0 +1,33 @@
+# Champion First Pass
+
+**Visibility:** Evidence map + prior product discussion; not Challenger conclusions.  
+**Evidence boundary:** Public platform docs + local deploy inventory + ADR drafts intent.  
+**Not validated:** End-to-end OTel JSONL capture on this host; mount CLI.
+
+## Thesis
+
+The correct architecture split is:
+
+1. **Observe at the host** (ADR-0001), with Claude local OTel as the first concrete adapter (Appendix B).  
+2. **Disclose at the catalog/pack layer** (ADR-0002), because skill-internal progressive disclosure cannot cap description tax at 100+ skills.  
+3. Ship **S0 artifacts now** (ADRs + catalog + validator) without pretending S1 mount exists.
+
+## Why this bet
+
+- Matches industry PD + discovery index patterns without inventing a new skill format.  
+- Removes the unsafe default of rewriting third-party `SKILL.md` for metrics.  
+- Gives a falsifiable Core size (34) under the ≤80 discoverable target **once mounts exist**.  
+- Keeps control-plane skills distinct (no mega-skill merge).
+
+## Claims that must not be made yet
+
+- “Context window already saved.”  
+- “We have cross-agent usage analytics in production.”  
+- “Core list is empirically optimal.”  
+
+## P0 scope Champion defends
+
+- ADR texts + Appendix B privacy tree.  
+- Catalog covering 100% deploy membership.  
+- Validator gate green.  
+- Explicit limitations + stages S0→S3.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/03-challenger-first-pass.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/03-challenger-first-pass.md
@@ -1,0 +1,38 @@
+# Challenger First Pass
+
+**Visibility:** Evidence map + Champion thesis known (same-session contamination — honesty requires noting this).  
+**Evidence boundary:** Same as Evidence Clerk.  
+**Not validated:** User willingness to enable OTel tool details; mount UX.
+
+## Attack
+
+### 1. Catalog theater (severity: high)
+
+Publishing `skills-pack-catalog.yaml` with `enforcement: none` does **not** change Claude/Factory discovery. Calling this “On-demand 落地” would be false advertising. Without S1, description budget remains ~7k tokens.
+
+### 2. Privacy bait-and-switch (severity: high)
+
+Appendix B’s useful per-skill reports require `OTEL_LOG_TOOL_DETAILS=1`, which expands tool-detail exposure. Teams may “just enable it” and violate the ADR’s own privacy tree. ADR must treat TOOL_DETAILS as a **separate consent gate**, not a footnote.
+
+### 3. Chicken-and-egg Core list (severity: medium)
+
+Core=34 is an opinion without usage evidence. Wrong Core either wastes context or hides needed skills. ADR-0002 admits this but still risks social locking of a bad list.
+
+### 4. Residual pack is a landfill (severity: medium)
+
+`residual_library` holds ~50 skills. That recreates sprawl inside one on-demand bucket and undermines “pack = coherent domain.”
+
+### 5. Cross-platform overclaim (severity: medium)
+
+Cursor Enterprise analytics ≠ local JSONL; Codex hooks missing. A “unified observability architecture” doc can smuggle readiness across agents.
+
+### 6. Validator false confidence (severity: low→medium)
+
+Custom YAML parser + membership check proves **coverage**, not **mount correctness** or **token budget**. Passing validator ≠ progressive disclosure works.
+
+## Demands
+
+- Acceptance language must say **S0 contract only**.  
+- Residual pack marked as **debt to split**, not a stable architecture end-state.  
+- No promotion claiming measured context savings.  
+- Preserve disagreement if Owner wants hard enforcement before telemetry.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/04-cross-examination.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/04-cross-examination.md
@@ -1,0 +1,21 @@
+# Cross-Examination
+
+## Challenger → Champion
+
+**Q1:** Without S1, why accept ADR-0002 as architecture rather than a backlog note?  
+**A1:** Because the decision (catalog-level PD + pack mounts) changes what we refuse to build (super-index skill, canary-as-metrics). S0 is a binding non-goal set + artifact contract. **Label:** Product-owner decision + Repo-derived inference.  
+**Limitation accepted:** No context savings claim until S1.
+
+**Q2:** Does Appendix B create pressure to enable TOOL_DETAILS?  
+**A2:** Risk acknowledged. ADR-0001 updated with **separate consent gate** and ban on claiming named adoption without it. **Label:** Fact (doc update) + Opinion (process will be followed).
+
+**Q3:** Is `residual_library` fatal?  
+**A3:** Not fatal for S0 if marked debt (S4) and not marketed as elegant taxonomy. **Label:** Opinion. Challenger retains medium severity as accepted unresolved risk.
+
+## Champion → Challenger
+
+**Q4:** Should we block ADR promotion until live OTel capture succeeds on this host?  
+**A4 (Challenger):** Block **production telemetry rollout** claims; do not block S0 architecture docs if Appendix B remains “procedure not executed.” **Resolution:** scope removed for e2e OTel from this acceptance.
+
+**Q5:** Is Enterprise-only Cursor a reason to reject host-first strategy?  
+**A5:** No — it strengthens host-first *with adapters and honesty about gaps*. Reject only if docs claim parity. **Label:** Fact (Enterprise gate) + Opinion (strategy still sound).

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/05-objections-and-disagreements.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/05-objections-and-disagreements.md
@@ -1,0 +1,38 @@
+# Objections and Disagreements
+
+| ID | Severity | Claim attacked | Evidence class | Resolution type | Remaining risk | Required next proof | Veto |
+|---|---|---|---|---|---|---|---|
+| O1 | high | “On-demand already saves context” | missing evidence | scope removed — S0 forbids savings claim | Readers still misread ADR titles | S1 mount demo + before/after description token count | no-veto (scoped) |
+| O2 | high | TOOL_DETAILS casually enabled with telemetry | hypothesis | test/gate added — separate consent gate text in ADR-0001 | Process drift | Ops note template when first enabling TOOL_DETAILS | no-veto |
+| O3 | medium | Core=34 is correct forever | opinion | accepted unresolved | Bad Core locks | ADR-0001 signals → revise catalog | no-veto |
+| O4 | medium | `residual_library` is coherent architecture | repo-derived inference | accepted unresolved + S4 stage | Landfill pack | Split proposal ADR or catalog revision | no-veto |
+| O5 | medium | Unified cross-agent observability ready | missing evidence | scope removed — adapters + gaps listed | Vendor drift | Per-agent adapter acceptance | no-veto |
+| O6 | low | Validator proves PD works | fact | rejected with evidence — validator only proves membership/schema | False confidence in CI | Keep acceptance wording narrow | no-veto |
+
+## Preserved disagreements
+
+```text
+Disagreement: Whether S0 catalog should live under docs/adr/artifacts vs only machine ~/.agents until S1 exists.
+Why unresolved: Prefer repo-canonical architecture vs deploy-local truth; both valid.
+Decision owner: Product owner
+Evidence needed: First successful S1 mount using the repo catalog as input
+What must not be claimed yet: Repo catalog is the live mount source of truth for agents
+```
+
+```text
+Disagreement: Whether residual_library should be empty before accepting ADR-0002.
+Why unresolved: Emptying requires many subjective pack splits now; delays S0.
+Decision owner: Product owner
+Evidence needed: Usage clusters or explicit owner pack map
+What must not be claimed yet: Pack taxonomy is complete
+```
+
+## False-consensus probe
+
+What would make this consensus dangerously wrong?
+
+1. Teams enable TOOL_DETAILS broadly and leak secrets via tool args in OTel.  
+2. Operators believe catalog YAML alone unmounted skills (no savings, false security of “we fixed sprawl”).  
+3. Core omits a daily-used skill; users disable pack discipline and remount everything.  
+
+Survives only with: separate consent gate, S0 honesty banner, Core revision loop via ADR-0001.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/06-claim-ledger.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/06-claim-ledger.md
@@ -1,0 +1,14 @@
+# Claim Ledger
+
+| Claim | Label | Evidence | Confidence | Validation path | Reversal condition | Must not claim yet |
+|---|---|---|---|---|---|---|
+| Canary inject is invasive and proxy-only | Fact | skill-debug accuracy contract | high | Re-read SKILL.md | Platform makes canary unnecessary | Canary proves usefulness |
+| Claude has skill_activated OTel | Fact | Claude monitoring docs 2026-07-17 | high | Re-fetch docs / run local capture | Docs remove event | Works without TELEMETRY=1 |
+| Cursor skills analytics are Enterprise | Fact | Cursor Analytics API docs | high | Re-fetch docs | API opens to all plans | Personal Cursor has same API |
+| Codex lacks stable skill hooks | Fact / Hypothesis | Public issue + OTel docs | medium | Track Codex releases | Hooks ship | Codex equals Claude skill events |
+| Host-first layered observability is the architecture bet | Product-owner decision | ADR-0001 | high | Owner reject | Owner reverts to canary-default | Implemented on all agents |
+| Catalog-level PD complements skill PD | Repo-derived inference | Industry PD + scale analysis | high | S1 token budget experiment | Experiment shows no savings | Already saving tokens today |
+| Catalog lists all 129 deploy skills once | Fact | validator PASS | high | Re-run validator | Deploy drift | Mounts match catalog |
+| Core size 34 is a good permanent set | Opinion / Hypothesis | Draft catalog | low | Usage signals | Data contradicts | Empirically optimal |
+| Appendix B is executable procedure | Fact (text) | ADR-0001 appendix | medium | Live capture on host | Steps fail on current Claude | Capture already done in this acceptance |
+| This review is independent L3 | Out of scope | Independence = L1 | high | N/A | N/A | “Independent expert review” |

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/07-rubric-decision.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/07-rubric-decision.md
@@ -1,0 +1,26 @@
+# Rubric Decision
+
+Scores 0–3. Critical dimensions marked *.
+
+| Dimension | Score | Notes |
+|---|---|---|
+| Evidence* | 3 | Platform docs + validator + deploy inventory cited |
+| Independence honesty* | 3 | Explicit L1; forbids independent wording |
+| Strategic sharpness | 3 | Host-first + catalog PD; rejects super-index & canary-default |
+| User truth | 2 | Owner/machine ICP clear; broader team ICP thin |
+| Differentiation | 2 | Behavioral (non-invasive + pack mount stages), not hype |
+| Commercial reality | 1 | Not a commercial ADR; treated as out of primary scope |
+| Feasibility | 3 | S0 shipped; S1 bounded; non-goals clear |
+| AI-native integrity | 2 | Changes measurement/routing loop, not branding |
+| Trust and safety* | 3 | Consent gate for TOOL_DETAILS; canary demoted |
+| Scope discipline | 3 | S0–S4; savings claims deferred |
+| Adversarial force* | 3 | High objections forced doc edits (consent gate, S0 banner, residual debt) |
+| Decision quality* | 3 | accept-with-limitations; preserved disagreements |
+| Falsifiability* | 3 | Validator gate; S1 token experiment; consent misuse monitors |
+
+**Critical zeros:** none.
+
+**Decision:** **accept-with-limitations**
+
+**Next:** Optional S1 mount prototype; optional live Appendix B capture on owner machine.  
+**Reversal evidence:** S1 fails to reduce description tokens; or TOOL_DETAILS becomes de-facto mandatory without controls; or owner rejects host-first for canary-default.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/08-owner-decision.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/08-owner-decision.md
@@ -1,0 +1,32 @@
+# Final Product Judgment
+
+**Decision:** accept-with-limitations  
+
+ADR-0001 and ADR-0002 are accepted as **architecture supplements** for skills-refiner: non-invasive, host-first observability (with Claude OTel Appendix B as the first adapter procedure), and catalog-level progressive disclosure via a draft pack map.
+
+## What becomes canonical
+
+- `docs/adr/0001-non-invasive-skill-observability.md`  
+- `docs/adr/0002-on-demand-pack-catalog.md`  
+- `docs/adr/artifacts/skills-pack-catalog.yaml` (status: **draft**, enforcement: **none**)  
+- Validator as membership/schema gate only  
+
+## What does not become canonical
+
+- Claim that context window is already reduced.  
+- Claim of production cross-agent usage analytics.  
+- Claim that Core=34 is empirically optimal.  
+- Claim that this package is L3/L4 independent review.  
+- Claim that `residual_library` is a finished taxonomy.  
+
+## Limitations (binding)
+
+1. S0 only — mount runtime is future work (S1).  
+2. Appendix B procedure accepted as text; **e2e capture not executed** in this acceptance.  
+3. Review independence is **L1**.  
+4. Cursor/Codex gaps remain named, not papered over.
+
+## Promotion boundary
+
+May update machine-side pointers (`SCALE-ANALYSIS`, `DEBT-BACKLOG`) to cite these ADRs.  
+Must **not** promote as organization-wide telemetry standard or enforced pack mounts without S1 + Owner decision + preferably ≥L3 review for org rollout.

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/acceptance.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/acceptance.md
@@ -1,0 +1,5 @@
+# Acceptance
+
+Canonical acceptance record:
+
+[`docs/verification/2026-07-17-observability-pack-catalog-acceptance.md`](../../verification/2026-07-17-observability-pack-catalog-acceptance.md)

--- a/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/final-product-judgment.md
+++ b/docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/final-product-judgment.md
@@ -1,0 +1,5 @@
+# Final Product Judgment
+
+See [08-owner-decision.md](08-owner-decision.md) for the canonical judgment text.
+
+**Decision:** accept-with-limitations (S0 architecture ADRs + draft catalog).

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -4,6 +4,10 @@ This repository has three distinct runtime surfaces: host-agent `SKILL.md`
 loading, Bash-based read-only governance/observability, and the local cleanup
 CLI. Support on one surface does not imply support on another.
 
+Architecture supplements for **non-invasive usage telemetry** and **on-demand
+pack catalogs** live under [`docs/adr/`](adr/README.md) (ADR-0001, ADR-0002).
+Those ADRs do not expand the cleanup mutation support matrix below.
+
 ## Support matrix
 
 | Environment | Skill content | Read-only governance (`scan`, `probe`, `dashboard`, `doctor`) | Trace transform / canary | Cleanup review | Cleanup mutation (`plan`, `apply`, `status`, `undo`) | `setup-cli` |

--- a/docs/verification/2026-07-17-observability-pack-catalog-acceptance.md
+++ b/docs/verification/2026-07-17-observability-pack-catalog-acceptance.md
@@ -1,0 +1,45 @@
+# Acceptance — ADR-0001 / ADR-0002 / Pack Catalog (S0)
+
+**Date:** 2026-07-17  
+**Judge:** accept-with-limitations  
+**Independence:** L1 (role-separated; **not** independent)
+
+## Scope checklist
+
+| ID | Item | Result | Evidence |
+|---|---|---|---|
+| A1 | ADR-0001 written with layered model + non-goals | PASS | `docs/adr/0001-non-invasive-skill-observability.md` |
+| A2 | Appendix B (Claude OTel → local JSONL) inside ADR-0001 | PASS | § Appendix B + consent gate |
+| A3 | ADR-0002 pack catalog decision + stages | PASS | `docs/adr/0002-on-demand-pack-catalog.md` |
+| A4 | Catalog artifact A covers deploy membership | PASS | validator listed=129 deploy=129 |
+| A5 | ADR index README | PASS | `docs/adr/README.md` |
+| A6 | Adversarial package complete | PASS | `docs/adversarial-product-pk/2026-07-17-observability-pack-catalog/` |
+| A7 | Severe objections addressed or preserved | PASS | O1–O6 in `05-objections-and-disagreements.md` |
+
+## Runnable gate executed
+
+```bash
+node docs/adr/artifacts/validate-skills-pack-catalog.mjs
+# Observed 2026-07-17: PASS skills-pack-catalog validation
+# core_count: 34  listed_count: 129  deploy_count: 129
+# Paths in tool output are home-redacted (e.g. ~/.agents/skills), not absolute usernames.
+```
+
+## Explicit non-claims
+
+- No claim that On-demand mounts are active on Claude/Factory/Cursor.  
+- No claim that Claude OTel JSONL capture was run end-to-end on this host.  
+- No claim of L3/L4 independent review.  
+- No claim that canary inject is retired from the codebase — only demoted as default analytics path in architecture.
+
+## Falsification monitors
+
+1. Docs or marketing state “context saved by catalog” before S1 exists.  
+2. `OTEL_LOG_TOOL_DETAILS` enabled in shared/CI defaults without consent record.  
+3. Catalog validator fails (membership drift) and is ignored.  
+4. `residual_library` grows without S4 split plan after new installs.
+
+## Next recommended proofs (optional)
+
+1. Owner runs Appendix B.6 once; attach redacted event sample to verification note.  
+2. Prototype S1 mount for `profile: core` only; measure description token delta.


### PR DESCRIPTION
## Summary
- Add ADR-0001 (host-first skill usage observability; demote canary inject; Claude OTel local appendix with privacy gates).
- Add ADR-0002 + draft `skills-pack-catalog.yaml` + membership validator (home-path redacted in logs).
- Record L1 adversarial review and S0 acceptance; no claim of live mount savings or e2e OTel capture.

## Privacy audit
- Branch introduces **no** absolute `/Users/<name>` paths, tokens, or secrets in new/changed files.
- Validator logs use `~/...` redaction.
- Machine-local `~/.agents/skills` policy edits were **not** committed (remain on host only).
- Pre-existing note: older `docs/adversarial-product-pk/2026-07-14-skill-disposition/00-evidence-map.md` on `main` already contains a local repo absolute path (out of this PR scope).

## Test plan
- [x] `node docs/adr/artifacts/validate-skills-pack-catalog.mjs` → PASS (129/129)
- [x] Secret/PII scan on files changed by this branch → clean
- [ ] Optional: owner runs Appendix B.6 OTel capture locally (not required for merge)


Made with [Cursor](https://cursor.com)